### PR TITLE
決済ページのURL変更

### DIFF
--- a/backend/app/services/stripe_service.py
+++ b/backend/app/services/stripe_service.py
@@ -21,8 +21,8 @@ def create_checkout_session(firebase_uid: str):
             },
         ],
         mode="payment",
-        success_url=YOUR_DOMAIN + "/admin/subscription/success",
-        cancel_url=YOUR_DOMAIN + "/admin/subscription/cancel",
+        success_url=YOUR_DOMAIN + "/admin/payment/success",
+        cancel_url=YOUR_DOMAIN + "/admin/payment/cancel",
         metadata={
             "firebase_uid": firebase_uid,  # Firebase UIDをメタデータに保存
         },

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -221,7 +221,7 @@ export default function AdminPage() {
           <Button
             variant="outline"
             className="w-full flex items-center justify-center py-4 border-orange-200 hover:bg-orange-50"
-            onClick={() => router.push('/admin/subscription')}
+            onClick={() => router.push('/admin/payment')}
           >
             <CreditCard className="mr-2 h-5 w-5 text-orange-600" />
             <span className="text-orange-800">プレミアムプラン購入</span>


### PR DESCRIPTION
タイトル　決済ページのURL変更
## issue番号　概要
#3 管理者画面からプレミアムプラン購入を押した先の遷移先修正/決済後の成功ページ、キャンセルページの遷移先を修正

本文
## issue番号
#3

## やったこと
- frontend\src\app\admin\page.tsxにおいて、遷移先を/admin/subscription→/admin/paymentに変更
- backend\app\services\stripe_service.pyにおいて、遷移先を/admin/subscription/success→/admin/payment/successに変更、キャンセルページも同様に変更

## やらないこと
デプロイ作業（次の段階で行う）

## できるようになること（ユーザ目線）
支払い作業が出来るようになる

## できなくなること（ユーザ目線）
なし

## 特にレビューして欲しい箇所
遷移先URLが問題ないか

## 動作確認
遷移先が問題ないことを確認してほしい

## その他
