### PR TITLE
Vercelでeslintによるデプロイエラーを防ぐ

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true, // VercelでのESLintエラーを無視
+  },
   reactStrictMode: true,
   images: {
     remotePatterns: [


### PR DESCRIPTION
タイトル Vercelでeslintによるデプロイエラーを防ぐ
## issue番号　概要
#7    Vercelでeslintによるデプロイエラーを防ぐ

本文
## issue番号
#7 

## やったこと
next.config.jsに以下の内容を追記
```
eslint: {
    ignoreDuringBuilds: true, // VercelでのESLintエラーを無視
 },
```

## やらないこと
ルール対応

## できるようになること（ユーザ目線）
デプロイ

## できなくなること（ユーザ目線）


## 特にレビューして欲しい箇所


## 動作確認


## その他
